### PR TITLE
Upgrade to ppxlib.0.14.0

### DIFF
--- a/ppx_typerep_conv.opam
+++ b/ppx_typerep_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "base"    {>= "v0.14" & < "v0.15"}
   "typerep" {>= "v0.14" & < "v0.15"}
   "dune"    {>= "2.0.0"}
-  "ppxlib"  {>= "0.11.0"}
+  "ppxlib"  {>= "0.14.0"}
 ]
 synopsis: "Generation of runtime types from type declarations"
 description: "

--- a/src/ppx_typerep_conv.ml
+++ b/src/ppx_typerep_conv.ml
@@ -312,7 +312,7 @@ module Typerep_implementation = struct
       in
       let type_name_module = pmod_apply ~loc make type_name_struct in
       let module_def =
-        pstr_module ~loc @@ module_binding ~loc ~name:(Located.mk ~loc name)
+        pstr_module ~loc @@ module_binding ~loc ~name:(Located.mk ~loc (Some name))
                               ~expr:type_name_module
       in
       let typename_of_t =


### PR DESCRIPTION
The next release of ppxlib will use the 4.10 AST internally. This PR makes ppx_typerep_conv compatible with this new version. Probably worth waiting for the new release before merging this!