### PR TITLE
Achieve compatibility with ppxlib 0.22.0

### DIFF
--- a/ppx_typerep_conv.opam
+++ b/ppx_typerep_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "base"    {>= "v0.14" & < "v0.15"}
   "typerep" {>= "v0.14" & < "v0.15"}
   "dune"    {>= "2.0.0"}
-  "ppxlib"  {>= "0.14.0"}
+  "ppxlib"  {>= "0.22.0"}
 ]
 synopsis: "Generation of runtime types from type declarations"
 description: "

--- a/src/ppx_typerep_conv.ml
+++ b/src/ppx_typerep_conv.ml
@@ -184,7 +184,7 @@ module Typerep_implementation = struct
 
     val arg_of_param : string -> string
 
-    val params_names : params:(core_type * variance) list -> string list
+    val params_names : params:(core_type * (variance * injectivity)) list -> string list
     val params_patts : loc:Location.t -> params_names:string list -> pattern list
 
     val type_name_module_definition : loc:Location.t -> path:string ->
@@ -233,7 +233,7 @@ module Typerep_implementation = struct
     let str_item_type_and_name ~loc ~path ~params_names ~type_name =
       let params =
         List.map params_names
-          ~f:(fun name -> (ptyp_var ~loc name, Invariant))
+          ~f:(fun name -> (ptyp_var ~loc name, (NoVariance, NoInjectivity)))
       in
       let td =
         let manifest =


### PR DESCRIPTION
In ppxlib 0.22.0, the AST gets bumped to ocaml 4.12. This commit adapts to the compiler changes from 4.11 to 4.12: mainly, the introduction of injectivity to type declarations.

It would be good to merge this PR when ppxlib 0.22.0 gets released, which will be soon.

cc @NathanReb